### PR TITLE
Fix gem's load path

### DIFF
--- a/home_loan_resource.gemspec
+++ b/home_loan_resource.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = Dir["{lib,vendor}/**/*"] + ["MIT-LICENSE", "README.md"]
+  spec.require_paths = ['lib']
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/home_loan_resource/version.rb
+++ b/lib/home_loan_resource/version.rb
@@ -1,3 +1,3 @@
 module HomeLoanResource
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
The `spec.require_path` has gathering all inner directories but was
actually missing the `lib` directory. So that's why we couldn't resolve
the dependency.

With this change it just sets the lib directory and now we can do:
`require 'home_loan_resource'` without error.

Tested locally changing the project's `Gemfile` to:

```
gem 'home_loan_resource', '~> 0.1.2', path: 'my/local/path'
```

And running `bundle install`.